### PR TITLE
Loosen rdkafka dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     racecar (2.11.0)
       king_konf (~> 1.0.0)
-      rdkafka (~> 0.15.0)
+      rdkafka (>= 0.15.2, < 0.19)
 
 GEM
   remote: https://rubygems.org/
@@ -33,7 +33,7 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     rake (13.0.6)
-    rdkafka (0.15.1)
+    rdkafka (0.18.0)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
-  spec.add_runtime_dependency "rdkafka",   "~> 0.15.0"
+  spec.add_runtime_dependency "rdkafka", ">= 0.15.2", "< 0.19"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
Since https://github.com/Shopify/activekafka/issues/1340 (done in https://github.com/Shopify/activekafka/pull/1342 and https://github.com/Shopify/kafka-shopify/pull/1253), Shopify's home grown kafka clients require rdkafka v0.18

In shop-server, we're still in the process of migrating away from Racecar which requires rdkafka 0.15.

This PR loosen the dependency on rdkafka to allow for 0.18 to be used